### PR TITLE
Threading

### DIFF
--- a/BrillouinAcquisition/acquisition.cpp
+++ b/BrillouinAcquisition/acquisition.cpp
@@ -183,6 +183,7 @@ void Acquisition::startAcquisition(ACQUISITION_SETTINGS acqSettings) {
 	emit(s_acqCalibrationRunning(false));
 	emit(s_acqProgress(ACQUISITION_STATES::FINISHED, 100.0, 0));
 	emit(s_acqTimeToCalibration(0));
+	delete m_fileHndl;
 }
 
 void Acquisition::abort() {
@@ -194,6 +195,7 @@ void Acquisition::abort() {
 	emit(s_acqProgress(ACQUISITION_STATES::ABORTED, 0, 0));
 	emit(s_acqPosition(m_startPosition[0], m_startPosition[1], m_startPosition[2], 0));
 	emit(s_acqTimeToCalibration(0));
+	delete m_fileHndl;
 }
 
 void Acquisition::setSettings(ACQUISITION_SETTINGS acqSettings) {

--- a/BrillouinAcquisition/acquisition.cpp
+++ b/BrillouinAcquisition/acquisition.cpp
@@ -42,7 +42,7 @@ void Acquisition::startAcquisition(ACQUISITION_SETTINGS acqSettings) {
 	m_startPosition = m_scanControl->getPosition();
 
 	m_fileHndl = new StorageWrapper(nullptr, m_acqSettings.filename, H5F_ACC_RDWR);
-	QMetaObject::Connection connection = connect(m_fileHndl, SIGNAL(finished()), m_fileHndl, SLOT(deleteLater()));
+	//QMetaObject::Connection connection = connect(m_fileHndl, SIGNAL(finished()), m_fileHndl, SLOT(deleteLater()));
 	// move h5bm file to separate thread
 	//m_storageThread.startWorker(m_fileHndl);
 

--- a/BrillouinAcquisition/acquisition.cpp
+++ b/BrillouinAcquisition/acquisition.cpp
@@ -44,7 +44,7 @@ void Acquisition::startAcquisition(ACQUISITION_SETTINGS acqSettings) {
 	m_fileHndl = new StorageWrapper(nullptr, m_acqSettings.filename, H5F_ACC_RDWR);
 	QMetaObject::Connection connection = connect(m_fileHndl, SIGNAL(finished()), m_fileHndl, SLOT(deleteLater()));
 	// move h5bm file to separate thread
-	m_storageThread.startWorker(m_fileHndl);
+	//m_storageThread.startWorker(m_fileHndl);
 
 	std::string now = QDateTime::currentDateTime().toOffsetFromUtc(QDateTime::currentDateTime().offsetFromUtc())
 		.toString(Qt::ISODateWithMs).toStdString();

--- a/BrillouinAcquisition/acquisition.h
+++ b/BrillouinAcquisition/acquisition.h
@@ -58,7 +58,7 @@ public slots:
 
 private:
 	ACQUISITION_SETTINGS m_acqSettings;
-	Thread m_storageThread;
+	//Thread m_storageThread;
 	StorageWrapper *m_fileHndl = nullptr;	// file handle
 	Andor *m_andor;
 	ScanControl *m_scanControl;

--- a/BrillouinAcquisition/storageWrapper.cpp
+++ b/BrillouinAcquisition/storageWrapper.cpp
@@ -20,10 +20,12 @@ StorageWrapper::~StorageWrapper() {
 
 void StorageWrapper::s_enqueuePayload(IMAGE *img) {
 	m_payloadQueue.enqueue(img);
+	s_writeQueues();
 }
 
 void StorageWrapper::s_enqueueCalibration(CALIBRATION *cal) {
 	m_calibrationQueue.enqueue(cal);
+	s_writeQueues();
 }
 
 void StorageWrapper::s_finishedQueueing() {
@@ -67,16 +69,5 @@ void StorageWrapper::s_writeQueues() {
 		m_writtenCalibrationsNr++;
 		delete cal;
 		cal = nullptr;
-	}
-
-	// continue to write queues if
-	// m_observeQueues is true
-	// m_abort was not set from the outside
-	// m_finishedQeueuing shows that more queue entries will come
-	if (m_observeQueues && !m_abort && !m_finishedQueueing) {
-		QMetaObject::invokeMethod(this, "s_writeQueues", Qt::QueuedConnection);
-	} else {
-		m_finished = true;
-		emit finished();
 	}
 }


### PR DESCRIPTION
This PR is a workaround for a weird bug for which I didn't find the root cause yet. When the acquired images are written in a separate thread, writing images fails for images which are written after the acquisition finished. This should not happen, because all objects necessary for writing are still alive when writing images.

For now, the image writing happens in the same thread. This seems to result in a minor speed decrease (approx. 3 % slower) for full field images and in no decrease for 400 px times 400 px images.